### PR TITLE
feat: build and test against 3.14

### DIFF
--- a/.github/workflows/nox-test.yaml
+++ b/.github/workflows/nox-test.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     name: Test Python ${{ matrix.python-version }}
     steps:
@@ -50,6 +50,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true # For Python 3.14 pre-releases
 
       - name: Setup virtualenv
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install build deps
         run: |
-          python -m pip --disable-pip-version-check install cibuildwheel==2.21.3 twine==5.1.1 setuptools
+          python -m pip --disable-pip-version-check install cibuildwheel==3.2.0 twine==6.2.0 setuptools cffi>=2.0.0
 
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: runner.os == 'Linux'

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ and can be installed with `pip` or `pipenv`::
     pip install --user cmarkgfm
     pipenv install cmarkgfm
 
-Wheels are provided for macOS, Linux, and Windows for Python 3.9, 3.10, 3.11, 3.12, and 3.13.
+Wheels are provided for macOS, Linux, and Windows for Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14.
 
 
 Usage

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import shutil
 import nox
 
 
-@nox.session(py=['3.9', '3.10', '3.11', '3.12', '3.13'])
+@nox.session(py=['3.9', '3.10', '3.11', '3.12', '3.13', '3.14'])
 def unit(session):
     session.install('pytest', 'pytest-cov')
     session.install('.')

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,12 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     cffi_modules=["src/cmarkgfm/build_cmark.py:ffibuilder"],
+    python_requires='>=3.9',
     setup_requires=["cffi>=2.0.0", "pycparser>=2.06"],
     install_requires=["cffi>=2.0.0"],
     project_urls={


### PR DESCRIPTION
Python 3.14 is set to be released early October.
Refs: https://peps.python.org/pep-0745/

Update build-time dependencies, test matrix.