### PR TITLE
chore: use modern Python syntax

### DIFF
--- a/src/cmarkgfm/build_cmark.py
+++ b/src/cmarkgfm/build_cmark.py
@@ -1,7 +1,6 @@
 import distutils.ccompiler
 import distutils.dist
 import glob
-import io
 import os
 
 import cffi
@@ -19,10 +18,10 @@ WIN_GENERATED_SRC_DIR = os.path.join(PACKAGE_ROOT, 'generated', 'windows')
 CMARK_DEF_H_PATH = os.path.join(HERE, 'cmark.cffi.h')
 CMARK_MODULE_H_PATH = os.path.join(HERE, 'cmark_module.h')
 
-with io.open(CMARK_DEF_H_PATH, 'r', encoding='utf-8') as fh:
+with open(CMARK_DEF_H_PATH, encoding='utf-8') as fh:
     CMARK_DEF_H = fh.read()
 
-with io.open(CMARK_MODULE_H_PATH, 'r', encoding='utf-8') as fh:
+with open(CMARK_MODULE_H_PATH, encoding='utf-8') as fh:
     CMARK_MODULE_H = fh.read()
 
 
@@ -36,7 +35,7 @@ def _get_sources(dir, exclude=set()):
     ])
 
 
-SOURCES = _get_sources(SRC_DIR, exclude=set(['main.c']))
+SOURCES = _get_sources(SRC_DIR, exclude={'main.c'})
 SOURCES.extend(_get_sources(EXTENSIONS_SRC_DIR))
 
 

--- a/src/cmarkgfm/cmark.py
+++ b/src/cmarkgfm/cmark.py
@@ -1,13 +1,12 @@
 """Python bindings to GitHub's cmark Markdown library."""
 
-from __future__ import unicode_literals
 
 from cmarkgfm import _cmark
 
 CMARK_VERSION = "0.29.0.gfm.2"
 
 
-class Options(object):
+class Options:
     CMARK_OPT_DEFAULT = _cmark.lib.CMARK_OPT_DEFAULT
     CMARK_OPT_SOURCEPOS = _cmark.lib.CMARK_OPT_SOURCEPOS
     CMARK_OPT_HARDBREAKS = _cmark.lib.CMARK_OPT_HARDBREAKS
@@ -66,7 +65,7 @@ def markdown_to_html_with_extensions(text, options=0, extensions=None):
     for extension_name in extensions:
         extension = find_syntax_extension(extension_name)
         if extension is None:
-            raise ValueError('Unknown extension {}'.format(extension_name))
+            raise ValueError(f'Unknown extension {extension_name}')
         cmark_extensions.append(extension)
 
     parser = parser_new(options=options)


### PR DESCRIPTION
- `open()` is a built-in, no need for `io.`
- All literals are unicode
- Use `f`-strings instead of `.format()`